### PR TITLE
Utility functions for coloring.

### DIFF
--- a/scripts/settings/set_boldface.m
+++ b/scripts/settings/set_boldface.m
@@ -1,4 +1,4 @@
-function set_boldface( setting )
+function set_boldface( setting, res_tags )
 % set_boldface( setting )
 %
 % Set name labels to be boldface or not, depending on setting.
@@ -6,7 +6,12 @@ function set_boldface( setting )
 % (C) R. Das, Stanford University, 2017
 
 if ~exist( 'setting', 'var' ) setting = 1; end;
-res_tags = get_tags( 'Residue' );
+
+% if you don't pass res_tags, get all residues.
+if nargin < 2
+    res_tags = get_tags( 'Residue' );
+end;
+
 if setting == 1; fontweight = 'bold'; else; fontweight = 'normal'; end;
 
 for i = 1:length( res_tags )
@@ -16,6 +21,9 @@ for i = 1:length( res_tags )
     end
 end
 
-plot_settings = getappdata( gca, 'plot_settings' );
-plot_settings.boldface = setting;
-setappdata( gca, 'plot_settings', plot_settings );
+% Only change the global plot_settings if res_tags not specified
+if nargin < 2
+    plot_settings = getappdata( gca, 'plot_settings' );
+    plot_settings.boldface = setting;
+    setappdata( gca, 'plot_settings', plot_settings );
+end;

--- a/scripts/settings/set_fontcolor.m
+++ b/scripts/settings/set_fontcolor.m
@@ -1,0 +1,19 @@
+function set_fontcolor( color, res_tags )
+% set_fontcolor( setting, res_tags )
+%
+% Set font color for a selection of residues (or all of them).
+%
+% (C) R. Das, Stanford University, 2017
+
+
+% if you don't pass res_tags, get all residues.
+if nargin < 2
+    res_tags = get_tags( 'Residue' );
+end;
+
+for i = 1:length( res_tags )
+    residue = getappdata( gca, res_tags{i} );
+    if isfield( residue, 'handle' ) 
+        set( residue.handle, 'color', pymol_RGB( color ) );
+    end
+end

--- a/scripts/util/ribodraw_figure_out_stem_assignment.m
+++ b/scripts/util/ribodraw_figure_out_stem_assignment.m
@@ -18,7 +18,7 @@ else % assume partner vector is given
     end
 end
 
-stems = ribodraw_parse_stems_from_bps( bps );
+stems = parse_stems_from_bps( bps );
 
 stem_assignment = zeros(1,length(secstruct));
 for i = 1:length( stems )


### PR DESCRIPTION
```
>> set_boldface(1, {'Residue_A13545' 'Residue_A13546'})
>> set_fontcolor('orange', {'Residue_A13544' 'Residue_A13545'})
```
yields:
![image](https://user-images.githubusercontent.com/5008491/77375462-edea1980-6d43-11ea-8322-ddc26740cac9.png)
