### PR TITLE
Fix eterna_export bug

### DIFF
--- a/scripts/docs/util/ribodraw_convert_bps_to_structure.html
+++ b/scripts/docs/util/ribodraw_convert_bps_to_structure.html
@@ -77,7 +77,7 @@ This function is called by:
 0024 <span class="keyword">if</span> length( bps ) == 0; <span class="keyword">return</span>; <span class="keyword">end</span>;
 0025 
 0026 <span class="comment">% break up into helices (stems)</span>
-0027 stems = parse_stems_from_bps( bps );
+0027 stems = ribodraw_parse_stems_from_bps( bps );
 0028 
 0029 <span class="comment">% convert into helix_map format (this is historical):</span>
 0030 <span class="comment">% Looks like partner i of first base pair, partner j of first base pair,</span>


### PR DESCRIPTION
When attempting to export eterna, would error that could not find "parse_stems_from_bps" in "ribodraw_convert_bps_to_structure", it appears that parse_stems_from_bps was changed to ribodraw_parse_stems_from_bps. Tested by Grace.